### PR TITLE
OPENEUROPA-ISSUE-51 Check if the object Role is not null

### DIFF
--- a/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.post_update.php
+++ b/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.post_update.php
@@ -23,9 +23,13 @@ function oe_editorial_corporate_workflow_post_update_set_validator_permission(ar
  * Adapts translator role name.
  */
 function oe_editorial_corporate_workflow_post_update_00001(): void {
-  \Drupal::entityTypeManager()
+  $role = \Drupal::entityTypeManager()
     ->getStorage('user_role')
-    ->load('oe_translator')
-    ->set('label', 'Translate content')
-    ->save();
+    ->load('oe_translator');
+
+  if ($role) {
+    $role
+      ->set('label', 'Translate content')
+      ->save();
+  }
 }


### PR DESCRIPTION
## OPENEUROPA-ISSUE-51

### Description

Check if the load for oe_translator Role returns a non-empty value

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh

```

